### PR TITLE
feat: initial draft for FUSE write support

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -185,6 +185,10 @@ impl Fs {
     }
 
     pub async fn add(&mut self, dir: String, content: String) -> Result<()> {
+        self.write(dir, content.into_bytes()).await
+    }
+
+    pub async fn write(&mut self, dir: String, content: Vec<u8>) -> Result<()> {
         let path = PathSegments::from_path(dir)?;
 
         match path {

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -167,8 +167,8 @@ impl FuseFs {
             NodeKind::File => FileType::RegularFile,
         };
         let perm = match node.kind() {
-            NodeKind::Directory => 0o555,
-            NodeKind::File => 0o444,
+            NodeKind::Directory => 0o755,
+            NodeKind::File => 0o644,
         };
         let size = node.size(&self.fs).unwrap_or(0);
         let nlink = match node.kind() {

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -493,6 +493,45 @@ impl Filesystem for FuseFs {
         }
     }
 
+    // TODO: Properly do this
+    fn setattr(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        _size: Option<u64>,
+        _atime: Option<fuser::TimeOrNow>,
+        _mtime: Option<fuser::TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<u64>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<u32>,
+        reply: ReplyAttr,
+    ) {
+        let attr = FileAttr {
+            ino,
+            size: 0,
+            blocks: 0,
+            nlink: 2,
+            perm: 0o755,
+            uid: self.config.uid,
+            gid: self.config.gid,
+            rdev: 0,
+            flags: 0,
+            blksize: BLOCK_SIZE as u32,
+            kind: FileType::RegularFile,
+            atime: SystemTime::now(),
+            mtime: SystemTime::now(),
+            ctime: SystemTime::now(),
+            crtime: SystemTime::now(),
+        };
+        reply.attr(&TTL, &attr)
+    }
+
     fn release(
         &mut self,
         _req: &Request<'_>,


### PR DESCRIPTION
Not proposing to merge this yet, but wanted to share: Initial draft for FUSE write support!
Works (at least very basically) for both public and private files. Does only support append-only writes, no random writes.

```
~/Code/rust/appa fuse-write
$ echo "hello" > /tmp/mnt/private/hello.txt

~/Code/rust/appa fuse-write
$ cat /tmp/mnt/private/hello.txt
hello

```

The whole to-be-written file is collected in memory and flushed once the file handle is released. This of course is not good for large files, can easily overflow available memory. To fix this in a nice way wnfs has to become  `Send` first because currently the `Fs` handle cannot be shared between threads. Or the API of wnfs would have to change a bit I guess. I'll investigate more.

And there's likely quite a few more edge cases that should be covered properly.